### PR TITLE
[ARCH-894] ignore extra responses from batch request

### DIFF
--- a/src/Facebook/FacebookBatchResponse.php
+++ b/src/Facebook/FacebookBatchResponse.php
@@ -106,6 +106,10 @@ class FacebookBatchResponse extends FacebookResponse implements IteratorAggregat
         // @TODO With PHP 5.5 support, this becomes array_column($response['headers'], 'value', 'name')
         $httpResponseHeaders = isset($response['headers']) ? $this->normalizeBatchHeaders($response['headers']) : [];
 
+        if (! $originalRequest) {
+            return;
+        }
+
         $this->responses[$originalRequestName] = new FacebookResponse(
             $originalRequest,
             $httpResponseBody,

--- a/tests/FacebookBatchResponseTest.php
+++ b/tests/FacebookBatchResponseTest.php
@@ -161,4 +161,27 @@ class FacebookBatchResponseTest extends BaseTestCase
           'ETag' => '"barTag"',
         ], $batchResponse[1]->getHeaders());
     }
+
+    public function testExtraResponsesAreIgnored()
+    {
+        $graphResponseJson = '[';
+        $graphResponseJson .= '{"code":200,"headers":[],"body":"{}"},'; // Response key 0
+        $graphResponseJson .= '{"code":200,"headers":[],"body":"{}"},'; // Extra response key 1
+        $graphResponseJson .= '{"code":200,"headers":[],"body":"{}"}'; // Extra response key 2
+        $graphResponseJson .= ']';
+        $response = new FacebookResponse($this->request, $graphResponseJson, 200);
+
+        $requests = [
+            new FacebookRequest($this->app, 'foo_token_one', 'GET', '/me'),
+        ];
+
+        $batchRequest = new FacebookBatchRequest($this->app, $requests);
+        $batchResponse = new FacebookBatchResponse($batchRequest, $response);
+
+        $response = $batchResponse->getResponses();
+
+        self::assertTrue(isset($response[0]));
+        self::assertFalse(isset($response[1]));
+        self::assertFalse(isset($response[2]));
+    }
 }


### PR DESCRIPTION
For some reason, the batch comment request seems to be returning responses not requested based on error reported in https://commentsold.atlassian.net/browse/ARCH-894.

Ignore responses not present in the requests sent. `FacebookResponse` doesn't allow null for its first argument anyway, so this is probably not a bad idea in general.